### PR TITLE
More changes for compatibility with Python3

### DIFF
--- a/ma/checkers/checker_file_utils.py
+++ b/ma/checkers/checker_file_utils.py
@@ -80,7 +80,7 @@ def get_all_statements(names, file_name):
      """
     # Split list to avoid problem with command size
     size = 2500
-    names = [names[x: x + size] for x in xrange(0, len(names), size)]
+    names = [names[x: x + size] for x in range(0, len(names), size)]
 
     lines = []
     for name in names:
@@ -197,7 +197,7 @@ def _check_token(token, names):
     case, it will go through all the list as usual. """
 
     max_regex = 99
-    grouped_names = [names[i: i + max_regex] for i in xrange(0, len(names), max_regex)]
+    grouped_names = [names[i: i + max_regex] for i in range(0, len(names), max_regex)]
     for sub_names in grouped_names:
         regexes = "(" + ")|(".join(sub_names) + ")"
         if re.match(regexes, token) is not None:

--- a/ma/controller.py
+++ b/ma/controller.py
@@ -23,8 +23,11 @@ limitations under the License.
 """
 
 import sys
+import glob
 from clang.cindex import Index
+from clang.cindex import Config
 from clang.cindex import TranslationUnit
+clang_library_file = ''
 
 from .checkers.asm_checker import AsmChecker
 from .checkers.long_double_checker import LongDoubleChecker
@@ -70,6 +73,7 @@ def run(args):
 
 
 def _run_checker(checker, mode, set_of_files):
+    global clang_library_file
     if mode == 'full':
         files = core.get_files(set_of_files)
     else:
@@ -81,6 +85,12 @@ def _run_checker(checker, mode, set_of_files):
     else:
         print(__current_wip(checker, files))
         visitor = Visitor(checker)
+        if clang_library_file == '':
+            clang_libraries = glob.glob('/usr/lib*/libclang.so*')
+            reverse_list = list(reversed(clang_libraries))
+            if reverse_list:
+                clang_library_file = reverse_list[0]
+                Config.set_library_file(clang_library_file)
         index = Index.create()
         for c_file in files:
             root = index.parse(c_file, options=TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD)

--- a/ma/core.py
+++ b/ma/core.py
@@ -63,7 +63,7 @@ def execute_stdout(command):
     try:
         output = subprocess.check_output([command], stderr=subprocess.STDOUT,
                                          shell=True)
-        return 0, output
+        return 0, output.decode()
     except subprocess.CalledProcessError as excp:
         return excp.returncode, excp.output
 

--- a/ma/ma.py
+++ b/ma/ma.py
@@ -68,7 +68,8 @@ def main(argv=None):
         parser.add_argument('-V', '--version',
                             action='version',
                             version=program_version_message)
-        subparsers = parser.add_subparsers(help='\nMA commands\n\n')
+        subparsers = parser.add_subparsers(help='\nMA commands\n\n',
+            dest='subcommand')
         # Arguments for the run subcommand
         parser_run = subparsers.add_parser(
             'run',
@@ -157,6 +158,9 @@ def main(argv=None):
             )
         # Process arguments
         args = parser.parse_args()
+        if args.subcommand == None:
+            parser.print_help()
+            return 1
         controller.run(args)
     except KeyboardInterrupt:
         return 1

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if ma.core.cmdexists('clang'):
     reverse_list = list(reversed(clang_installed))
     if reverse_list:
         clang_version = reverse_list[0].split('/')[-1][:-2]
-        clang_line = 'clang==' + clang_version
+        clang_line = 'clang<=' + clang_version
         with open(requirement_file, 'a+') as req_file:
             if not any(clang_line in line for line in req_file):
                 req_file.write(clang_line + '\n')
@@ -51,7 +51,8 @@ requirements = [str(required.req) for required in requirements_list]
 
 setup(
     name='ma',
-    version='1.0.timestamp'+clang_version.replace('.', ''),
+    #version='1.0.timestamp'+clang_version.replace('.', ''),
+    version='1.0.timestamp',
     description='Migrates C/C++ applications to POWER',
     long_description=readme,
     author='Rafael Peria de Sene, Roberto Guimarães Dutra de Oliveira, \


### PR DESCRIPTION
1. `xrange()` is missing in Python3. `range()` can be used instead and for
   both Python2 and Python3.

2. For whatever reason, the clang Python bindings can't seem to find the
   Python library, so find it ourselves and tell the binding.  Sigh.

3. `subprocess.check_output()` returns a bytearray, which is just a pain,
   so convert it to a string before returning from `execute_stdout()`.

4. `parser.parse_args()` can't seem to deal if there is no subcommand
   provided anymore, so ensure it is set, even if to `None`, then explicitly
   print the help text if it is indeed set to `None`.

5. The clang Python bindings don't seem to keep up well with the clang
   implementation, so allow earlier versions of the bindings, and cross
   your fingers that what you get works.  The alternative is that `setup.py`
   fails, which is suboptimal.  Also remove the clang version from the
   version, because it now does not seem to have that much value.

Signed-off-by:  Paul A. Clarke <pc@us.ibm.com>