### PR TITLE
Even more changes for compatibility

### DIFF
--- a/ma/problem_reporter.py
+++ b/ma/problem_reporter.py
@@ -93,7 +93,7 @@ class ProblemReporter(object):
                 print(tab + "File: " + file_name)
                 for problem in problems:
                     print((tab * 2) + "Line: " + str(problem.line))
-                    print((tab * 2) + "Problem: " + problem.name)
+                    print((tab * 2) + "Problem: " + str(problem.name))
                     if problem.solution:
                         print((tab * 2) + "Solution: " + problem.solution)
                     print("")


### PR DESCRIPTION
The clang parser seems to have become more robust in more recent versions,
which results in more errors when the code is indexed.  Try to accommodate
some of the errors by more effectively searching for dependent include files:
- extract the default list of include paths from GCC (this is a hack)
- pass that list to the clang indexer
- also allow many more errors so that indexing will complete instead of
  bailing because of "too many errors"

Also, another `bytearray` needing to be converted to `str`.

Signed-off-by:  Paul A. Clarke <pc@us.ibm.com>