### PR TITLE
Add `--verbose` option

### DIFF
--- a/ma/controller.py
+++ b/ma/controller.py
@@ -50,22 +50,22 @@ from .help import HelpCreator
 from . import core
 
 
-def run(args):
+def run(argv):
     """
     Executes the correct action according the user input.
 
     Parameters:
-        args - arguments collected by argparser
+        argv - arguments collected by argparser
     """
 
-    if 'checker_info' in args:
+    if 'checker_info' in argv:
         chelp = HelpCreator()
-        chelp.create_help(args.checker_info)
+        chelp.create_help(argv.checker_info)
         sys.exit(0)
-    for chk in _load_checkers(args.checkers):
-        _run_checker(chk, args.execution_mode, args.location[0])
+    for chk in _load_checkers(argv.checkers):
+        _run_checker(chk, argv)
 
-    statistics = args.statistics
+    statistics = argv.statistics
     if statistics:
         statistic = Statistics(statistics)
         statistic.stat()
@@ -94,12 +94,12 @@ def _include_paths():
     return include_paths
 
 
-def _run_checker(checker, mode, set_of_files):
+def _run_checker(checker, argv):
     global clang_library_file
-    if mode == 'full':
-        files = core.get_files(set_of_files)
+    if argv.execution_mode == 'full':
+        files = core.get_files(argv.location[0])
     else:
-        files = core.get_files(set_of_files, checker.get_pattern_hint())
+        files = core.get_files(argv.location[0], checker.get_pattern_hint())
     if not files:
         cnf = 'Could not find any problem related to '
         cnf += checker.get_problem_type().lower()

--- a/ma/ma.py
+++ b/ma/ma.py
@@ -68,6 +68,8 @@ def main(argv=None):
         parser.add_argument('-V', '--version',
                             action='version',
                             version=program_version_message)
+        parser.add_argument('-v', '--verbose', action='store_true',
+                            help='verbose output')
         subparsers = parser.add_subparsers(help='\nMA commands\n\n',
             dest='subcommand')
         # Arguments for the run subcommand


### PR DESCRIPTION
- Support a `--verbose` / `-v` option which can be used to emit more information.
- Use the verbose option to emit information about errors and warnings generated during clang indexing.
- Pass `argv` instead of individual members to `_run_checker`.
- Change a uses of `args` to `argv` to better represent its purpose and avoid a conflict with a local variable.

The new option is global, rather than associated with a subcommand, so
the command syntax would be, for example:
```
$ ma --verbose run -c asm .
```
Signed-off-by:  Paul A. Clarke <pc@us.ibm.com>