### PR TITLE
Commit to python3; use pkutils

### DIFF
--- a/dev
+++ b/dev
@@ -43,7 +43,7 @@ clean(){
 
 buildTests(){
 	createVirtEnv
-	python ./setup.py test
+	python3 ./setup.py test
 	destroyVirtEnv
 	clean
 	return $TRUE
@@ -51,7 +51,7 @@ buildTests(){
 
 buildRun(){
 	createVirtEnv
-	python ./setup.py install
+	python3 ./setup.py install
 	ma -h
 	destroyVirtEnv
 	clean
@@ -60,16 +60,16 @@ buildRun(){
 
 buildInstall(){
 	clean
-	python ./setup.py sdist
-	python ./setup.py check -m
+	python3 ./setup.py sdist
+	python3 ./setup.py check -m
     sudo pip install --upgrade ./dist/*.tar.gz
 	return $TRUE
 }
 
 buildClean(){
 	clean
-	python ./setup.py clean --all
-	python ./setup.py build
+	python3 ./setup.py clean --all
+	python3 ./setup.py build
 	return $TRUE
 }
 
@@ -80,8 +80,8 @@ buildCleanAll(){
 
 buildRelease(){
 	clean
-	python ./setup.py sdist
-	python ./setup.py check -m
+	python3 ./setup.py sdist
+	python3 ./setup.py check -m
 	return $TRUE
 }
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ limitations under the License.
 """
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+#from pip.req import parse_requirements
+import pkutils
 import glob
 import ma.core
 
@@ -46,8 +47,7 @@ else:
     print('Looks like you do not have clang installed. Install it first.')
     exit(2)
 
-requirements_list = parse_requirements(requirement_file, session=False)
-requirements = [str(required.req) for required in requirements_list]
+requirements = list(pkutils.parse_requirements(requirement_file))
 
 setup(
     name='ma',


### PR DESCRIPTION
`pip.req` seems to be gone, so switch to `pkutils`.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>